### PR TITLE
added edittext id that missing at joingroup

### DIFF
--- a/app/src/main/res/layout/activity_join_group.xml
+++ b/app/src/main/res/layout/activity_join_group.xml
@@ -35,6 +35,7 @@
             android:layout_height="wrap_content"
             android:textSize="25dp"/>
         <com.beardedhen.androidbootstrap.BootstrapEditText
+            android:id="@+id/edit_message"
             xmlns:app="http://schemas.android.com/apk/res-auto"
             android:layout_weight="5"
             android:textSize="25sp"


### PR DESCRIPTION
added edittext id that missing at joingroup
![image](https://cloud.githubusercontent.com/assets/13826224/18034447/70cab8cc-6d67-11e6-8b90-da810cc9d9a9.png)
